### PR TITLE
Make password argument optional for redshift schema dump script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@ python script, 'show create table' equivalent for aws redshift. Command-line syn
 
 Basic usage: 
 ```
-./show_create_table.py -h HOST -U USER -d DBNAME -W PASSWORD [-p PORT]
+show_create_table.py -h HOST -U USER -d DBNAME [-W PASSWORD] [-p PORT]
 [-f FILE] [-F {directory}] [-n SCHEMANAME]
-[-t TABLENAME]
+[-t TABLENAME] [-c PGPASS_FILE]
 ```
 
 ## Required parameters
 * [-h/--host=] HOSTNAME: hostname for Redshift database 
 * [-U/--user=] USERNAME: username to connect to Redshift database with
 * [-d/--dbname=] DBNAME: name of database to connect to on host
-* [-W/--password=] PASSWORD: Redshift password for username
 
 ## Optional parameters
 * [-p/--port=] PORT: port to connect to, defaults to 5432
@@ -24,3 +23,5 @@ which creates directories for each non-system schema and creates a separate SQL 
 * [-n/--schema=] SCHEMANAME: name of schema to show tables from, if none provided it will iterate over all 
 non-system schemas
 * [-t/--table=] TABLENAME: name of a single table to dump, if none provided it will iterate over all in schema
+* [-W/--password=] PASSWORD: Redshift password for username. If not provided, it will look for .pgpass credential file under user home directory, or file specified in '-c/--credential' argument.
+* [-c/--credential=] PGPASS_FILE: the path to the file containing Redshift connection credential, default path is <user_home_directory>/.pgpass. See https://www.postgresql.org/docs/9.1/static/libpq-pgpass.html

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Basic usage:
 ```
 ./show_create_table.py -h HOST -U USER -d DBNAME [-W PASSWORD] [-p PORT]
 [-f FILE] [-F {directory}] [-n SCHEMANAME]
-[-t TABLENAME] [-c PGPASS_FILE]
+[-t TABLENAME]
 ```
 
 ## Required parameters
@@ -16,6 +16,7 @@ Basic usage:
 * [-d/--dbname=] DBNAME: name of database to connect to on host
 
 ## Optional parameters
+* [-W/--password=] PASSWORD: Redshift password for username. If not provided, it will look for .pgpass credential file under user home directory, or file defined in PGPASSFILE system variable. See https://www.postgresql.org/docs/9.1/static/libpq-pgpass.html
 * [-p/--port=] PORT: port to connect to, defaults to 5432
 * [-f/--file=] FILE: file/directory to write output to, defaults to standard output
 * [-F/--format=] FORMAT: requires --file, currently only valid option (and default) is 'directory',
@@ -23,5 +24,3 @@ which creates directories for each non-system schema and creates a separate SQL 
 * [-n/--schema=] SCHEMANAME: name of schema to show tables from, if none provided it will iterate over all 
 non-system schemas
 * [-t/--table=] TABLENAME: name of a single table to dump, if none provided it will iterate over all in schema
-* [-W/--password=] PASSWORD: Redshift password for username. If not provided, it will look for .pgpass credential file under user home directory, or file specified in '-c/--credential' argument.
-* [-c/--credential=] PGPASS_FILE: the path to the file containing Redshift connection credential, default path is <user_home_directory>/.pgpass. See https://www.postgresql.org/docs/9.1/static/libpq-pgpass.html

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ python script, 'show create table' equivalent for aws redshift. Command-line syn
 
 Basic usage: 
 ```
-show_create_table.py -h HOST -U USER -d DBNAME [-W PASSWORD] [-p PORT]
+./show_create_table.py -h HOST -U USER -d DBNAME [-W PASSWORD] [-p PORT]
 [-f FILE] [-F {directory}] [-n SCHEMANAME]
 [-t TABLENAME] [-c PGPASS_FILE]
 ```

--- a/show_create_table.py
+++ b/show_create_table.py
@@ -8,7 +8,7 @@
  Neil Halelamien
 """
 
-from os import path, makedirs
+from os import path, makedirs, environ
 
 import psycopg2
 
@@ -215,9 +215,13 @@ def get_all_schemas(cur):
     return schemas
 
 
-def show_create_table(host, user, password, dbname, schemaname=None, tablename=None, port=5432):
-    conn = psycopg2.connect(
-        host=host, port=port, database=dbname, user=user, password=password)
+def show_create_table(host, user, dbname, schemaname=None, tablename=None, port=5432, password=None):
+    if password:
+        conn = psycopg2.connect(
+            host=host, port=port, database=dbname, user=user, password=password)
+    else:
+        conn = psycopg2.connect(
+            host=host, port=port, database=dbname, user=user)
     cur = conn.cursor()
     try:
         if schemaname is None and tablename is None:  # scan all non-system schemas and tables
@@ -244,9 +248,12 @@ def show_create_table(host, user, password, dbname, schemaname=None, tablename=N
         cur.close()
 
 
-def main(host, user, password, dbname, filename, file_format, schemaname=None, tablename=None, port=5432):
+def main(host, user, dbname, filename, file_format, schemaname=None, tablename=None, port=5432, password=None, pgpass_file=None):
+    if pgpass_file:
+        environ['PGPASSFILE']=pgpass_file
+
     for schema, table, stmt in show_create_table(
-            host, user, password, dbname, schemaname, tablename, port):
+            host, user, dbname, schemaname, tablename, port, password):
         if filename:
             if file_format == 'directory':
                 basedir = filename
@@ -272,7 +279,9 @@ if __name__ == '__main__':
     parser.add_argument('-h', '--host', required=True, dest='host')
     parser.add_argument('-U', '--user', required=True, dest='user')
     parser.add_argument('-d', '--dbname', required=True, dest='dbname')
-    parser.add_argument('-W', '--password', required=True, dest='password')
+    parser.add_argument('-W', '--password', required=False, dest='password',
+                        help='If no password is provided, the connector will attempt to authorize with .pgpass file in user\'s home directory, '
+                        'or the file specified in \'-c/--credential\' argument')
     parser.add_argument('-p', '--port', default=5432, dest='port')
     parser.add_argument('-f', '--file', default=False, dest='file',
                         help='file/directory to write output to, defaults to standard output')
@@ -283,16 +292,20 @@ if __name__ == '__main__':
                         help='Name of schema to show tables from, if not provided it will iterate over all non-system'
                              'schemas')
     parser.add_argument('-t', '--table', dest='tablename')
+    parser.add_argument('-c', '--credential', dest='pgpass_file',
+                        help='If provided, it will authorize postgres login attempt with colon-delimited connection string specified in credential file.' 
+                        'i.e "hostname:port:database:username:password"')
 
     args = parser.parse_args()
     main(
         args.host,
         args.user,
-        args.password,
         args.dbname,
         args.file,
         args.format,
         args.schemaname,
         args.tablename,
         args.port,
+        args.password,
+        args.pgpass_file,
     )

--- a/show_create_table.py
+++ b/show_create_table.py
@@ -8,7 +8,7 @@
  Neil Halelamien
 """
 
-from os import path, makedirs, environ
+from os import path, makedirs
 
 import psycopg2
 
@@ -248,10 +248,7 @@ def show_create_table(host, user, dbname, schemaname=None, tablename=None, port=
         cur.close()
 
 
-def main(host, user, dbname, filename, file_format, schemaname=None, tablename=None, port=5432, password=None, pgpass_file=None):
-    if pgpass_file:
-        environ['PGPASSFILE']=pgpass_file
-
+def main(host, user, dbname, filename, file_format, schemaname=None, tablename=None, port=5432, password=None):
     for schema, table, stmt in show_create_table(
             host, user, dbname, schemaname, tablename, port, password):
         if filename:
@@ -281,7 +278,7 @@ if __name__ == '__main__':
     parser.add_argument('-d', '--dbname', required=True, dest='dbname')
     parser.add_argument('-W', '--password', required=False, dest='password',
                         help='If no password is provided, the connector will attempt to authorize with .pgpass file in user\'s home directory, '
-                        'or the file specified in \'-c/--credential\' argument')
+                        'or the file defined in PGPASSFILE system variable')
     parser.add_argument('-p', '--port', default=5432, dest='port')
     parser.add_argument('-f', '--file', default=False, dest='file',
                         help='file/directory to write output to, defaults to standard output')
@@ -292,9 +289,6 @@ if __name__ == '__main__':
                         help='Name of schema to show tables from, if not provided it will iterate over all non-system'
                              'schemas')
     parser.add_argument('-t', '--table', dest='tablename')
-    parser.add_argument('-c', '--credential', dest='pgpass_file',
-                        help='If provided, it will authorize postgres login attempt with colon-delimited connection string specified in credential file.' 
-                        'i.e "hostname:port:database:username:password"')
 
     args = parser.parse_args()
     main(
@@ -307,5 +301,4 @@ if __name__ == '__main__':
         args.tablename,
         args.port,
         args.password,
-        args.pgpass_file,
     )


### PR DESCRIPTION
Thanks for creating this handy redshift schema dump util, I'm using it a lot to get the DDL from existing redshift tables. I would like to add the .pgpass lookup support in the script to allow connection without explicit password argument, which can be considered unsafe in circumstances.

Changes including:
- Make existing connection password argument(-W) optional;
- Added new optional argument(-c/--credential) for specifying pgpass connection credential file;
- Updated README

For details on pgpass file, please refer to https://www.postgresql.org/docs/9.1/static/libpq-pgpass.html.

Thanks for considering this PR request.

-Yang
